### PR TITLE
Support symlinks and add new template variables 'destination_dir' and 'source_dir'

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -2,6 +2,7 @@ package generator
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/rantav/go-archetype/inputs"
@@ -49,5 +50,7 @@ func collectSystemAndEnvironmentVariables(source, destination string) map[string
 	}
 	vars["source"] = source
 	vars["destination"] = destination
+	vars["source_dir"] = filepath.Base(source)
+	vars["destination_dir"] = filepath.Base(destination)
 	return vars
 }

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -50,7 +50,7 @@ func collectSystemAndEnvironmentVariables(source, destination string) map[string
 	}
 	vars["source"] = source
 	vars["destination"] = destination
-	vars["source_dir"] = filepath.Base(source)
-	vars["destination_dir"] = filepath.Base(destination)
+	vars["source_dirname"] = filepath.Base(source)
+	vars["destination_dirname"] = filepath.Base(destination)
 	return vars
 }

--- a/reader/reader.go
+++ b/reader/reader.go
@@ -2,6 +2,7 @@ package reader
 
 import (
 	"fmt"
+	"io/fs"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -56,7 +57,9 @@ func isDirectory(fi os.FileInfo) (bool, error) {
 		return true, nil
 	case mode.IsRegular():
 		return false, nil
+	case mode&fs.ModeSymlink != 0:
+		return false, nil
 	default:
-		return false, fmt.Errorf("unknown file mode (dir or file) at %s", fi)
+		return false, fmt.Errorf("unknown file mode (dir, file, or symlink) at %s", fi)
 	}
 }


### PR DESCRIPTION
Two small fixes here:
1. support symlinks as well as normal files in templates
2. add two more template variables, so we don't have to prompt the user to duplicate the repo name